### PR TITLE
fix: remove babel-polyfill from source

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   "extends": "airbnb-base",
   "rules": {
     "function-paren-newline": ["error", "consistent"],
+    "implicit-arrow-linebreak": "off",
     "object-curly-newline": ["error", { "consistent": true }]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-hit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -667,22 +667,6 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0",
         "regexpu-core": "^4.1.3"
-      }
-    },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
       }
     },
     "@babel/preset-env": {
@@ -1704,7 +1688,8 @@
     "core-js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
+      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-hit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   },
   "author": "strange-developer",
   "license": "MIT",
-  "dependencies": {
-    "@babel/polyfill": "^7.2.5"
-  },
   "devDependencies": {
     "@babel/cli": "^7.2.0",
     "@babel/core": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/strange-developer/cache-hit.git"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --ignore **/*.test.js",
+    "build": "babel src --out-dir lib",
     "test": "jest",
     "test:watch": "jest --watchAll --coverage",
     "lint": "./node_modules/.bin/eslint --ext .js ."

--- a/src/cache.js
+++ b/src/cache.js
@@ -5,8 +5,8 @@ const cache = {};
 const createCache = (promiseFunc, options = {}) => {
   const internalOptions = { timeToLive: calculateExpiry(options.timeToLive) };
 
-  function read({ key, forceInvoke = false }, ...parameters) {
-    return new Promise((resolve, reject) => {
+  const read = ({ key, forceInvoke = false }, ...parameters) =>
+    new Promise((resolve, reject) => {
       if (shouldInvokePromise(cache, key, internalOptions.timeToLive, forceInvoke)) {
         promiseFunc(...parameters)
           .then((promiseResponse) => {
@@ -19,7 +19,6 @@ const createCache = (promiseFunc, options = {}) => {
         resolve(cache[key]);
       }
     });
-  }
 
   return { read };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-import '@babel/polyfill';
-
 export { default } from './cache';

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -34,14 +34,14 @@ describe('With a promise that resolves successfully', () => {
   const promiseFunc = jest
     .fn()
     .mockReturnValue(
-      new Promise(resolve => setTimeout(() => resolve(PAYLOAD), 2500)),
+      new Promise(resolve => setTimeout(() => resolve(PAYLOAD), 100)),
     );
 
   let cachedPromise;
   let promise;
 
   beforeAll(() => {
-    cachedPromise = createCache(promiseFunc, { timeToLive: 499 });
+    cachedPromise = createCache(promiseFunc, { timeToLive: 10000 });
     promise = cachedPromise.read({ key: KEY }, PARAMETER_ONE, PARAMETER_TWO);
   });
 

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,124 @@
+import createCache from '../src/cache';
+
+describe('With a promise that fails', () => {
+  const ERROR = new Error('The promise failed');
+  const KEY = 'KEY_FAIL';
+  const promiseFunc = jest.fn().mockReturnValue(Promise.reject(ERROR));
+
+  let cachedPromise;
+
+  beforeAll(() => {
+    cachedPromise = createCache(promiseFunc);
+  });
+
+  test('Returns a rejected promise with the given error', () =>
+    cachedPromise
+      .read({ key: KEY })
+      .catch((error) => {
+        expect(error).toBe(ERROR);
+      }));
+
+  test('Calls the promise again and does not cache it', () =>
+    cachedPromise
+      .read({ key: KEY })
+      .catch(() => {
+        expect(promiseFunc.mock.calls.length).toBe(2);
+      }));
+});
+
+describe('With a promise that resolves successfully', () => {
+  const KEY = 'KEY_SUCCESS';
+  const PAYLOAD = 'PAYLOAD';
+  const PARAMETER_ONE = 'PARAMETER_ONE';
+  const PARAMETER_TWO = 'PARAMETER_TWO';
+  const promiseFunc = jest
+    .fn()
+    .mockReturnValue(
+      new Promise(resolve => setTimeout(() => resolve(PAYLOAD), 2500)),
+    );
+
+  let cachedPromise;
+  let promise;
+
+  beforeAll(() => {
+    cachedPromise = createCache(promiseFunc, { timeToLive: 499 });
+    promise = cachedPromise.read({ key: KEY }, PARAMETER_ONE, PARAMETER_TWO);
+  });
+
+  test('Calls the promise with the correct parameters', () =>
+    promise.then(() => {
+      expect(promiseFunc.mock.calls[0]).toEqual([PARAMETER_ONE, PARAMETER_TWO]);
+    }));
+
+  test('Resolves the promise with it\'s original response', () =>
+    promise.then((response) => {
+      expect(response).toBe(PAYLOAD);
+    }));
+
+  test('Returns the cached response when a second call is made', () =>
+    cachedPromise
+      .read({ key: KEY }, PARAMETER_ONE, PARAMETER_TWO)
+      .then(() => {
+        expect(promiseFunc.mock.calls.length).toBe(1);
+      }));
+});
+
+describe('When the cache expires', () => {
+  const KEY = 'KEY_EXPIRE';
+  const promiseFunc = jest
+    .fn()
+    .mockReturnValue(
+      new Promise(resolve => setTimeout(() => resolve(), 250)),
+    );
+
+  let cachedPromise;
+
+  beforeAll(() => {
+    cachedPromise = createCache(promiseFunc, { timeToLive: 1 });
+  });
+
+  beforeEach(() => new Promise(resolve => setTimeout(() => resolve(), 1)));
+
+  test('Runs the promise the first time', () =>
+    cachedPromise
+      .read({ key: KEY })
+      .then(() => {
+        expect(promiseFunc.mock.calls.length).toBe(1);
+      }));
+
+  test('Runs the promise the second time', () =>
+    cachedPromise
+      .read({ key: KEY })
+      .then(() => {
+        expect(promiseFunc.mock.calls.length).toBe(2);
+      }));
+});
+
+describe('With a forced invocation', () => {
+  const KEY = 'KEY_FORCE';
+  const promiseFunc = jest
+    .fn()
+    .mockReturnValue(
+      new Promise(resolve => setTimeout(() => resolve(), 250)),
+    );
+
+  let cachedPromise;
+
+  beforeAll(() => {
+    cachedPromise = createCache(promiseFunc, { timeToLive: 10000 });
+  });
+
+  test('Calls the promise the first time', () =>
+    cachedPromise
+      .read({ key: KEY })
+      .then(() => {
+        expect(promiseFunc.mock.calls.length).toBe(1);
+      }));
+
+  test('Calls the promise the second time', () =>
+    cachedPromise
+      .read({ forceInvoke: true, key: KEY })
+      .then(() => {
+        expect(promiseFunc.mock.calls.length).toBe(2);
+      }));
+});


### PR DESCRIPTION
`@babel/cli` already adds `regeneratorRuntime` to the transpiled code
the `@babel/polyfill` should be added by consumers if necessary